### PR TITLE
Bump MSBuild to allow going to NS1.3, which is more compatible with VS

### DIFF
--- a/Xamarin.Build.AsyncTask/Xamarin.Build.AsyncTask.csproj
+++ b/Xamarin.Build.AsyncTask/Xamarin.Build.AsyncTask.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard1.3</TargetFramework>
 
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
@@ -24,8 +24,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="14.3.0" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="14.3.0" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.6.82" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.6.82" />
 
     <PackageReference Include="NuGet.Build.Packaging" Version="*" PrivateAssets="all" />
     <PackageReference Include="GitInfo" Version="*" PrivateAssets="all" />

--- a/Xamarin.Build.AsyncTask/Xamarin.Build.AsyncTask.csproj
+++ b/Xamarin.Build.AsyncTask/Xamarin.Build.AsyncTask.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.6.82" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.6.82" />
 
+    <PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" PrivateAssets="all" />
     <PackageReference Include="NuGet.Build.Packaging" Version="*" PrivateAssets="all" />
     <PackageReference Include="GitInfo" Version="*" PrivateAssets="all" />
     <PackageReference Include="SourceLink.Create.GitHub" Version="*" PrivateAssets="all" />


### PR DESCRIPTION
Under VS, only net46 assemblies can run, since NS2.0 have indirect dependencies 
on netstandard.dll which doesn't ship with VS. 

See https://github.com/github/VisualStudio/issues/1849#issuecomment-411570902