### PR TITLE
Improve package versioning

### DIFF
--- a/Xamarin.Build.AsyncTask.sln
+++ b/Xamarin.Build.AsyncTask.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26929.2
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28711.60
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Xamarin.Build.AsyncTask", "Xamarin.Build.AsyncTask\Xamarin.Build.AsyncTask.csproj", "{A16B8369-E111-4BFE-8CA6-F24AB8C91609}"
 EndProject
@@ -11,6 +11,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.gitignore = .gitignore
 		GitInfo.txt = GitInfo.txt
 		LICENSE = LICENSE
+		NuGet.Config = NuGet.Config
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/Xamarin.Build.AsyncTask/AsyncTask.cs
+++ b/Xamarin.Build.AsyncTask/AsyncTask.cs
@@ -5,19 +5,6 @@ using System.Threading;
 using System.Collections;
 using System.Diagnostics;
 using System.Linq;
-using System.Reflection;
-
-// Keep AssemblyVersion constant and pointing to the base version, which is the "release", so to speak.
-[assembly: AssemblyVersion(ThisAssembly.Git.BaseVersion.Major + "." + ThisAssembly.Git.BaseVersion.Minor + "." + ThisAssembly.Git.BaseVersion.Patch)]
-// FileVersion and InformationalVersion hold the "right" values but don't mess with fusion.
-[assembly: AssemblyFileVersion(ThisAssembly.Git.SemVer.Major + "." + ThisAssembly.Git.SemVer.Minor + "." + ThisAssembly.Git.SemVer.Patch)]
-// Full metadata about branch and commit is always useful.
-[assembly: AssemblyInformationalVersion(
-  ThisAssembly.Git.SemVer.Major + "." +
-  ThisAssembly.Git.SemVer.Minor + "." +
-  ThisAssembly.Git.SemVer.Patch + "-" +
-  ThisAssembly.Git.Branch + "+" +
-  ThisAssembly.Git.Commit)]
 
 namespace Xamarin.Build
 {

--- a/Xamarin.Build.AsyncTask/Xamarin.Build.AsyncTask.csproj
+++ b/Xamarin.Build.AsyncTask/Xamarin.Build.AsyncTask.csproj
@@ -3,9 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netstandard1.3</TargetFramework>
 
-    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
-    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
     <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
     <NoWarn>1701;1702;1705;1591</NoWarn>
 
@@ -24,12 +21,23 @@
 
     <PackOnBuild>true</PackOnBuild>
     <InferPackageContents>false</InferPackageContents>
+    <GenerateNuspecDependsOn>SetVersions;$(GenerateNuspecDependsOn)</GenerateNuspecDependsOn>
+    <GetPackageVersionDependsOn>SetVersions;$(GetPackageVersionDependsOn)</GetPackageVersionDependsOn>
+
+    <GitBranch Condition="'$(SYSTEM_PULLREQUEST_TARGETBRANCH)' != ''">$(SYSTEM_PULLREQUEST_TARGETBRANCH)</GitBranch>
+    <GitBranch Condition="'$(SYSTEM_PULLREQUEST_TARGETBRANCH)' == '' and '$(BUILD_SOURCEBRANCHNAME)' != ''">$(BUILD_SOURCEBRANCHNAME)</GitBranch>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(CI)' == ''">
+    <CI>false</CI>
+    <CI Condition="'$(TF_BUILD)' == 'true'">true</CI>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.6.82" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.6.82" />
 
+    <PackageReference Include="MSBuilder.ThisAssembly.Metadata" Version="0.1.4" PrivateAssets="all" />
     <PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" PrivateAssets="all" />
     <PackageReference Include="NuGet.Build.Packaging" Version="*" PrivateAssets="all" />
     <PackageReference Include="GitInfo" Version="*" PrivateAssets="all" />
@@ -43,15 +51,81 @@
     <PackageFile Include="$(OutputPath)$(AssemblyName).pdb" Kind="lib" />
     <PackageFile Include="$(OutputPath)$(AssemblyName).xml" Kind="lib" />
     <PackageFile Include="Readme.txt" />
-    <PackageFile Include="Microsoft.Build.Tasks.Core;Microsoft.Build.Utilities.Core" Version="14.3.0">
-      <Kind>Dependency</Kind>
-    </PackageFile>
+    <PackageFile Include="Microsoft.Build.Tasks.Core;Microsoft.Build.Utilities.Core" Version="14.3.0" Kind="Dependency" Visible="false" />
   </ItemGroup>
 
-  <Target Name="SetPackageVersion" DependsOnTargets="GitVersion" BeforeTargets="GetPackageVersion">
+  <Target Name="Version" DependsOnTargets="SetVersions;GetAssemblyVersion" AfterTargets="SetVersions">
+    <Message Importance="high" Text="PackageVersion=$(PackageVersion)
+AssemblyVersion=$(AssemblyVersion)" />
+    <Message Condition="$(CI)" Importance="high" Text="##vso[build.updatebuildnumber]$(BuildVersion)"/>
+  </Target>
+
+  <Target Name="SetVersions"
+          BeforeTargets="PrepareForBuild;GetAssemblyVersion;GetPackageVersion;Pack"
+          DependsOnTargets="GitVersion"
+          Returns="$(Version)"
+          Condition="'$(GitInfoImported)' == 'true' And '$(ExcludeRestorePackageImports)' != 'true'">
+
     <PropertyGroup>
-      <PackageVersion>$(GitSemVerMajor).$(GitSemVerMinor).$(GitSemVerPatch)</PackageVersion>
+      <!-- We don't build stable versions from non-master branches. When the version came from the branch, we leave it as-is. -->
+      <GitSemVerDashLabel Condition="'$(GitBranch)' != 'master' and '$(GitSemVerDashLabel)' == '' and '$(GitSemVerSource)' != 'Branch'">-$(GitBranch)</GitSemVerDashLabel>
     </PropertyGroup>
+
+    <ItemGroup>
+      <VersionMetadata Include="$(GitCommits)" Condition="'$(GitSemVerDashLabel)' == '' and '$(GitCommits)' != '0'" />
+
+      <!-- Branch metadata always present for non-master branches, unless the existing label matches the branch.
+           For a versioned branch, it doesn't make sense either. -->
+      <VersionMetadata Include="$(GitBranch)" Condition="'$(GitBranch)' != 'master' and '$(GitSemVerSource)' != 'Branch' and '$(GitSemVerDashLabel)' != '-$(GitBranch)'" />
+
+      <VersionMetadata Condition="$(CI) and '$(BUILD_REASON)' == 'PullRequest'"
+                       Include="pr.$(SYSTEM_PULLREQUEST_PULLREQUESTNUMBER)"/>
+      <VersionMetadata Include="sha.$(GitCommit)" Condition="'$(GitCommit)' != ''"/>
+      <VersionMetadata Condition="$(CI)"
+                       Include="build.$(BUILD_BUILDID)"/>
+    </ItemGroup>
+
+    <PropertyGroup>
+      <VersionMetadataLabel>@(VersionMetadata -> '%(Identity)', '-')</VersionMetadataLabel>
+      <VersionMetadataPlusLabel Condition="'$(VersionMetadataLabel)' != ''">+$(VersionMetadataLabel)</VersionMetadataPlusLabel>
+      <GitSemVerDashLabel Condition="'$(GitSemVerDashLabel)' != '' and '$(GitCommits)' != '0'">$(GitSemVerDashLabel).$(GitCommits)</GitSemVerDashLabel>
+
+      <BuildVersion>$(GitBaseVersionMajor).$(GitBaseVersionMinor).$(GitBaseVersionPatch)$(GitSemVerDashLabel)$(VersionMetadataPlusLabel)</BuildVersion>
+
+      <!-- Stable versions should have clean version numbers with no metadata -->
+      <PackageVersion Condition="'$(GitSemVerDashLabel)' == ''">$(GitBaseVersionMajor).$(GitBaseVersionMinor).$(GitBaseVersionPatch)</PackageVersion>
+      <PackageVersion Condition="'$(GitSemVerDashLabel)' != ''">$(GitBaseVersionMajor).$(GitBaseVersionMinor).$(GitBaseVersionPatch)$(GitSemVerDashLabel)$(VersionMetadataPlusLabel)</PackageVersion>
+      <Version>$(BuildVersion)</Version>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <AssemblyAttribute Include="System.Reflection.AssemblyMetadata">
+        <_Parameter1>Version</_Parameter1>
+        <_Parameter2>$(Version)</_Parameter2>
+      </AssemblyAttribute>
+      <AssemblyAttribute Include="System.Reflection.AssemblyMetadata">
+        <_Parameter1>PackageVersion</_Parameter1>
+        <_Parameter2>$(PackageVersion)</_Parameter2>
+      </AssemblyAttribute>
+    </ItemGroup>
+
+  </Target>
+
+  <Target Name="AddVersionMetadata" DependsOnTargets="GetAssemblyVersion" BeforeTargets="GenerateThisAssemblyMetadata">
+    <ItemGroup>
+      <AssemblyAttribute Include="System.Reflection.AssemblyMetadata">
+        <_Parameter1>AssemblyVersion</_Parameter1>
+        <_Parameter2>$(AssemblyVersion)</_Parameter2>
+      </AssemblyAttribute>
+      <AssemblyAttribute Include="System.Reflection.AssemblyMetadata">
+        <_Parameter1>FileVersion</_Parameter1>
+        <_Parameter2>$(FileVersion)</_Parameter2>
+      </AssemblyAttribute>
+      <AssemblyAttribute Include="System.Reflection.AssemblyMetadata">
+        <_Parameter1>InformationalVersion</_Parameter1>
+        <_Parameter2>$(InformationalVersion)</_Parameter2>
+      </AssemblyAttribute>
+    </ItemGroup>
   </Target>
 
   <Import Project="Test.targets" />


### PR DESCRIPTION
This allows builds from branches and PRs to have distinct version numbers, so they are easy to test SxS with stable packages after downloading to a folder-based package source.

Also let the default SDK-style assembly versioning to take place, since tasks don't specify assembly versions and this would help diagnosing issues by having a specific assembly version.