### PR TITLE
Switch to ThisAssembly.Metadata from MSBuilder.ThisAssembly.Metadata

### DIFF
--- a/Xamarin.Build.AsyncTask/Version.targets
+++ b/Xamarin.Build.AsyncTask/Version.targets
@@ -54,26 +54,11 @@ AssemblyVersion=$(AssemblyVersion)" />
 
   <Target Name="AddVersionMetadata" DependsOnTargets="GetAssemblyVersion" BeforeTargets="GenerateThisAssemblyMetadata">
     <ItemGroup>
-      <AssemblyAttribute Include="System.Reflection.AssemblyMetadata">
-        <_Parameter1>Version</_Parameter1>
-        <_Parameter2>$(Version)</_Parameter2>
-      </AssemblyAttribute>
-      <AssemblyAttribute Include="System.Reflection.AssemblyMetadata">
-        <_Parameter1>PackageVersion</_Parameter1>
-        <_Parameter2>$(PackageVersion)</_Parameter2>
-      </AssemblyAttribute>
-      <AssemblyAttribute Include="System.Reflection.AssemblyMetadata">
-        <_Parameter1>AssemblyVersion</_Parameter1>
-        <_Parameter2>$(AssemblyVersion)</_Parameter2>
-      </AssemblyAttribute>
-      <AssemblyAttribute Include="System.Reflection.AssemblyMetadata">
-        <_Parameter1>FileVersion</_Parameter1>
-        <_Parameter2>$(FileVersion)</_Parameter2>
-      </AssemblyAttribute>
-      <AssemblyAttribute Include="System.Reflection.AssemblyMetadata">
-        <_Parameter1>InformationalVersion</_Parameter1>
-        <_Parameter2>$(InformationalVersion)</_Parameter2>
-      </AssemblyAttribute>
+      <AssemblyMetadata Include="Version" Value="$(Version)" />
+      <AssemblyMetadata Include="PackageVersion" Value="$(PackageVersion)" />
+      <AssemblyMetadata Include="AssemblyVersion" Value="$(AssemblyVersion)" />
+      <AssemblyMetadata Include="FileVersion" Value="$(FileVersion)" />
+      <AssemblyMetadata Include="InformationalVersion" Value="$(InformationalVersion)" />
     </ItemGroup>
   </Target>
 

--- a/Xamarin.Build.AsyncTask/Xamarin.Build.AsyncTask.csproj
+++ b/Xamarin.Build.AsyncTask/Xamarin.Build.AsyncTask.csproj
@@ -32,7 +32,10 @@
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.6.82" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.6.82" />
 
-    <PackageReference Include="MSBuilder.ThisAssembly.Metadata" Version="0.1.4" PrivateAssets="all" />
+    <PackageReference Include="ThisAssembly.Metadata" Version="1.4.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" PrivateAssets="all" />
     <PackageReference Include="NuGet.Build.Packaging" Version="*" PrivateAssets="all" />
     <PackageReference Include="GitInfo" Version="2.2.0" PrivateAssets="all" />


### PR DESCRIPTION
The NuGet `MSBuilder.ThisAssembly.Metadata` has been deprecated. Switch to ThisAssembly.Metadata instead.