### PR TITLE
Add Telemetry support. Bump to MSbuild 17+

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,14 @@ If you're creating an inline task that wants to inherit from AsyncTask, use the 
 as a template:
 
 ```xml
-  <UsingTask TaskName="MyAsyncTask" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+  <UsingTask TaskName="MyAsyncTask" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
     <ParameterGroup>
       <!-- TODO: your task parameters -->
     </ParameterGroup>
     <Task>
       <Reference Include="$(AsyncTask)" />
-      <Reference Include="System.Threading.Tasks"/>
+      <Reference Include="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll"/>
+      <Reference Include="$(MSBuildToolsPath)\Microsoft.Build.Utilities.Core.dll"/>
       <Code Type="Class" Language="cs">
         <![CDATA[
         public class MyAsyncTask : Xamarin.Build.AsyncTask

--- a/Xamarin.Build.AsyncTask/Readme.txt
+++ b/Xamarin.Build.AsyncTask/Readme.txt
@@ -5,13 +5,14 @@ If you're creating a custom task library, just inherit from Xamarin.Build.AsyncT
 If you're creating an inline task that wants to inherit from AsyncTask, use the following 
 as a template:
 
-  <UsingTask TaskName="MyAsyncTask" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+  <UsingTask TaskName="MyAsyncTask" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
     <ParameterGroup>
       <!-- TODO: your task parameters -->
     </ParameterGroup>
     <Task>
       <Reference Include="$(AsyncTask)" />
-      <Reference Include="System.Threading.Tasks"/>
+      <Reference Include="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll"/>
+      <Reference Include="$(MSBuildToolsPath)\Microsoft.Build.Utilities.Core.dll"/>
       <Code Type="Class" Language="cs">
         <![CDATA[
         public class MyAsyncTask : Xamarin.Build.AsyncTask

--- a/Xamarin.Build.AsyncTask/Test.targets
+++ b/Xamarin.Build.AsyncTask/Test.targets
@@ -9,15 +9,14 @@
     <AsyncMessage Text="Hello Async World!" />
   </Target>
 
-  <UsingTask TaskName="AsyncMessage" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+  <UsingTask TaskName="AsyncMessage" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)/Microsoft.Build.Tasks.Core.dll">
     <ParameterGroup>
       <Text Required="true" />
     </ParameterGroup>
     <Task>
       <Reference Include="$(OutputPath)$(AssemblyName).dll" />
-      <Reference Include="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll"/>
-      <Reference Include="$(MSBuildToolsPath)\Microsoft.Build.Utilities.Core.dll"/>
-      <Reference Include="System.Threading.Tasks"/>
+      <Reference Include="$(MSBuildToolsPath)/Microsoft.Build.Tasks.Core.dll"/>
+      <Reference Include="$(MSBuildToolsPath)/Microsoft.Build.Utilities.Core.dll"/>
       <Code Type="Class" Language="cs">
         <![CDATA[
         public class AsyncMessage : Xamarin.Build.AsyncTask
@@ -31,7 +30,9 @@
               await System.Threading.Tasks.Task.Delay(5000);
               LogMessage(Text);
 	            Complete();
-            });            
+            });
+
+            LogTelemetry("Test", new System.Collections.Generic.Dictionary<string, string> () {{"Property", "Value"}});
 
             return base.Execute();
           }

--- a/Xamarin.Build.AsyncTask/Xamarin.Build.AsyncTask.csproj
+++ b/Xamarin.Build.AsyncTask/Xamarin.Build.AsyncTask.csproj
@@ -7,11 +7,11 @@
     <NoWarn>1701;1702;1705;1591</NoWarn>
 
     <PackageId>Xamarin.Build.AsyncTask</PackageId>
-    <PackageVersion>0.4.0</PackageVersion>
+    <PackageVersion>0.5.0</PackageVersion>
 
     <Title>$(PackageId)</Title>
     <Description>$(PackageId)</Description>
-    <Summary>Supports MSBuild 14+.</Summary>
+    <Summary>Supports MSBuild 17+.</Summary>
     <Authors>Microsoft</Authors>
     <Owners>microsoft xamarin</Owners>
     <PackageReleaseNotes>$([System.IO.File]::ReadAllText('$(MSBuildThisFileDirectory)Readme.txt'))</PackageReleaseNotes>
@@ -29,8 +29,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.6.82" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.6.82" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.9.5" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.9.5" />
 
     <PackageReference Include="ThisAssembly.Metadata" Version="1.4.0">
       <PrivateAssets>all</PrivateAssets>
@@ -47,7 +47,7 @@
     <PackageFile Include="$(OutputPath)$(AssemblyName).pdb" Kind="lib" />
     <PackageFile Include="$(OutputPath)$(AssemblyName).xml" Kind="lib" />
     <PackageFile Include="Readme.txt" />
-    <PackageFile Include="Microsoft.Build.Tasks.Core;Microsoft.Build.Utilities.Core" Version="14.3.0" Kind="Dependency" Visible="false" />
+    <PackageFile Include="Microsoft.Build.Tasks.Core;Microsoft.Build.Utilities.Core" Version="17.0.0" Kind="Dependency" Visible="false" />
   </ItemGroup>
 
   <Import Project="Version.targets" />

--- a/Xamarin.Build.AsyncTask/Xamarin.Build.AsyncTask.csproj
+++ b/Xamarin.Build.AsyncTask/Xamarin.Build.AsyncTask.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;1591</NoWarn>
 
     <PackageId>Xamarin.Build.AsyncTask</PackageId>
-    <PackageVersion>0.6.0</PackageVersion>
+    <PackageVersion>0.4.0</PackageVersion>
 
     <Title>$(PackageId)</Title>
     <Description>$(PackageId)</Description>

--- a/Xamarin.Build.AsyncTask/Xamarin.Build.AsyncTask.csproj
+++ b/Xamarin.Build.AsyncTask/Xamarin.Build.AsyncTask.csproj
@@ -7,7 +7,7 @@
     <NoWarn>1701;1702;1705;1591</NoWarn>
 
     <PackageId>Xamarin.Build.AsyncTask</PackageId>
-    <PackageVersion>0.5.0</PackageVersion>
+    <PackageVersion>0.6.0</PackageVersion>
 
     <Title>$(PackageId)</Title>
     <Description>$(PackageId)</Description>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,6 +70,10 @@ extends:
           displayName: build libraries
           errorActionPreference: stop
         - powershell: |
+            & dotnet build Xamarin.Build.AsyncTask\Xamarin.Build.AsyncTask.csproj -c Release -t:Test -bl:$(LogDirectory)\Test.binlog
+          displayName: test libraries
+          errorActionPreference: stop
+        - powershell: |
             & dotnet pack Xamarin.Build.AsyncTask\Xamarin.Build.AsyncTask.csproj -c Release -bl:$(LogDirectory)\PackRelease.binlog
           displayName: pack NuGet
           errorActionPreference: stop


### PR DESCRIPTION
`IBuildEngine5` added support for sending Telemetry data https://learn.microsoft.com/en-us/dotnet/api/microsoft.build.framework.ibuildengine5.logtelemetry?view=msbuild-17-netcore. We need to expose a helper method in the `AsyncTask` so that tasks using it can log telemetry. 

We have to use the same pattern as we do for other logging event, the data should be queue'd and then disapatched on the main UI thread so that we can prevent locking. 